### PR TITLE
add ability to not run px4.launch in dynamics.launch

### DIFF
--- a/launch/dynamics.launch
+++ b/launch/dynamics.launch
@@ -11,7 +11,9 @@
     <arg name="airframe"                default="inno_standard_vtol"            doc="[inno_standard_vtol, babyshark_standard_vtol, iris]"/>
     <arg name="dynamics"                default="inno_vtol"                     doc="[inno_vtol, flightgoggles_multicopter]"/>
     <arg name="run_rviz"                default="false"                         doc="[true, false]"/>
-    <arg name="run_sitl_flight_stack"   default="true"                          doc="[true means sitl, false means true hitl]"/>
+    <arg name="run_sitl_flight_stack"   default="true"                          doc="[true means sitl, false means do nothing]"/>
+    <arg name="run_sitl_communicator"   default="false"                         doc="[true means run mavlink communicator, false means do nothing]"/>
+    <arg name="run_hitl_communicator"   default="false"                         doc="[true means run uavcan  communicator, false means do nothing]"/>
     <arg name="run_inno_sim_bridge"     default="true"                          doc="[true, false]"/>
 
 
@@ -27,12 +29,12 @@
     </group>
 
     <!-- 2. Run mavlink or uavcan communicator depending on simulation mode -->
-    <group if="$(arg run_sitl_flight_stack)">
+    <group if="$(arg run_sitl_communicator)">
         <node pkg="innopolis_vtol_dynamics" type="mavlink_communicator" name="mavlink_communicator" output="screen">
         <param name="vehicle"   value="$(arg vehicle)"  />
     </node>
     </group>
-    <group unless="$(arg run_sitl_flight_stack)">
+    <group if="$(arg run_hitl_communicator)">
         <node pkg="innopolis_vtol_dynamics" type="inno_vtol_reverse_mixer_node" name="inno_vtol_reverse_mixer" output="screen">
             <param name="vehicle"   value="$(arg vehicle)"  />
             <param name="airframe"  value="$(arg airframe)" />

--- a/launch/hitl.launch
+++ b/launch/hitl.launch
@@ -13,5 +13,7 @@
         <arg name="run_inno_sim_bridge"     value="$(arg run_inno_sim_bridge)"/>
 
         <arg name="run_sitl_flight_stack"   value="false"/>
+        <arg name="run_sitl_communicator"   value="false"/>
+        <arg name="run_hitl_communicator"   value="true"/>
     </include>
 </launch>

--- a/launch/sitl.launch
+++ b/launch/sitl.launch
@@ -4,6 +4,7 @@
     <arg name="dynamics"                default="inno_vtol"                     doc="[inno_vtol, flightgoggles_multicopter]"/>
     <arg name="run_rviz"                default="false"                         doc="[true, false]"/>
     <arg name="run_inno_sim_bridge"     default="true"                          doc="[true, false]"/>
+    <arg name="run_sitl_flight_stack"   default="true"                          doc="[true, false]"/>
 
     <include file="$(find innopolis_vtol_dynamics)/launch/dynamics.launch">
         <arg name="vehicle"                 value="$(arg vehicle)"/>
@@ -12,6 +13,8 @@
         <arg name="run_rviz"                value="$(arg run_rviz)"/>
         <arg name="run_inno_sim_bridge"     value="$(arg run_inno_sim_bridge)"/>
 
-        <arg name="run_sitl_flight_stack"   value="true"/>
+        <arg name="run_sitl_flight_stack"   value="$(arg run_sitl_flight_stack)"/>
+        <arg name="run_sitl_communicator"   value="true"/>
+        <arg name="run_hitl_communicator"   value="false"/>
     </include>
 </launch>


### PR DESCRIPTION
Extend dynamics.launch and related launch files with a parameter that… allows to not start px4.launch when sitl mode is choosen (it means that now we can separately run dynamics and px4.launch, so it adds an ability to run sitl mode from docker)